### PR TITLE
Allow [chars] as shorthand for [characters]

### DIFF
--- a/doc_source/syntax/characters.md
+++ b/doc_source/syntax/characters.md
@@ -13,7 +13,7 @@ The word is spelled: (park)[chars]
 ### Speech Markdown
 #### Short format
 ```text
-The word is spelled: (park)[chars]
+n/a
 ```
 
 #### Standard format

--- a/doc_source/syntax/characters.md
+++ b/doc_source/syntax/characters.md
@@ -5,7 +5,7 @@ Speaks a number or text as individual characters.
 ```text
 Countdown: (321)[characters]
 
-The word is spelled: (park)[characters]
+The word is spelled: (park)[chars]
 ```
 
 ---
@@ -13,7 +13,7 @@ The word is spelled: (park)[characters]
 ### Speech Markdown
 #### Short format
 ```text
-n/a
+The word is spelled: (park)[chars]
 ```
 
 #### Standard format


### PR DESCRIPTION
This is present in the JS implementation but missing from the spec